### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "psmid"
+description := "Portable 128-bit SIMD intrinsics."
+gitrepo     := "https://github.com/Maratyszcza/psimd.git"
+homepage    := "https://github.com/Maratyszcza/psimd/"
+license     := "MIT"
+version     := 072586a sha256:f6c4dab91ae9a03b3019e7cab0572743afd0e1b6e75b97fcca50259c737c924e https://github.com/Maratyszcza/psimd/archive/072586a.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

